### PR TITLE
fix: Re-find speed test table to prevent stale element error

### DIFF
--- a/main.py
+++ b/main.py
@@ -520,11 +520,17 @@ def run_speed_test_task(driver: WebDriver, access_code: str) -> Optional[SpeedRe
         # Wait directly for the results table to appear
         # instead of relying on the run button's state
         print("Waiting for gateway results table...")
-        table_selector = (By.CSS_SELECTOR, "table.grid.table100")
-        table = WebDriverWait(driver, 90).until(EC.visibility_of_element_located(table_selector))
-        print("Gateway speed test complete. Parsing results...")
+        # Use the wait only to confirm the table is ready
+        WebDriverWait(driver, 90).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, "table.grid.table100"))
+        )
 
+        print("Gateway speed test complete. Parsing results...")
         results: SpeedResults = {}
+
+        # THE FIX: Re-find the table now to get a fresh reference
+        table = driver.find_element(By.CSS_SELECTOR, "table.grid.table100")
+
         rows = table.find_elements(By.TAG_NAME, "tr")
         for row in rows:
             cols = row.find_elements(By.TAG_NAME, "td")

--- a/tests/test_selenium_tasks.py
+++ b/tests/test_selenium_tasks.py
@@ -115,12 +115,13 @@ def test_speed_test_task_success(mock_wait, mock_sleep, mock_driver):
     mock_table = MagicMock()
     mock_table.find_elements.return_value = [mock_row_down, mock_row_up]
 
-    mock_driver.find_element.return_value = MagicMock()  # for run button
+    # This mock will now handle the final table find, after the wait confirms visibility
+    mock_driver.find_element.return_value = mock_table
 
     mock_wait.return_value.until.side_effect = [
         TimeoutException("No password field"),  # First wait for password fails
         MagicMock(),  # Second wait for run button succeeds
-        mock_table,  # Third wait for results table visibility
+        True,  # Third wait for results table visibility (return value is ignored)
     ]
 
     results = run_speed_test_task(mock_driver, "test_code")


### PR DESCRIPTION
The script would occasionally fail with a "stale element reference" error when trying to parse the speed test results. This was caused by the webpage updating the results table a moment after it first became visible.

This change fixes the issue by re-finding the table element immediately before parsing its contents, ensuring the reference is always fresh.

The associated test `test_speed_test_task_success` was also updated to reflect the new `find_element` call in the code.