### PR TITLE
Simplify contributor docs and harden CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,31 @@
 name: CI
 
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
-    branches: [ main, master ]
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
-      - name: Install uv
-        run: pip install uv
-
-      - name: Sync dependencies
-        run: uv sync
-
-      - name: Ruff (lint)
-        run: uv run ruff check
-
-      - name: Ruff (format)
-        run: uv run ruff format . --check
-
-      - name: Type check (ty)
-        run: uv run ty check
-
-      - name: Tests
-        run: uv run pytest -q
+      - run: uv sync --locked
+      - run: uv run ruff check .
+      - run: uv run ruff format . --check
+      - run: uv run ty check
+      - run: uv run pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,3 @@ Prefer lint/type/tests for verification. Do not run `uv run python main.py` unle
 - Put agent-specific operational guidance here, not in the README.
 - Keep `main.py` script metadata dependencies in sync with `pyproject.toml`.
 - If behavior changes, update README, CONTRIBUTING, tests, and CI together when relevant.
-- Acknowledge AI assistance plainly and briefly; do not frame the repo as a portfolio project.
-
-## Current AI Tooling Context
-
-This repository has been developed with assistance from AI coding tools including Claude Code, Windsurf, and Codex. Human judgment owns the product scope, defaults, safety posture, and final review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,22 @@
-# Contributing Guide
+# Contributing
 
-Human and AI-assisted contributions are welcome. Review generated changes the same way as hand-written changes: keep them small, typed, lint-clean, tested, and free of secrets.
+Small fixes and practical improvements are welcome. For a larger change, open an issue first so we
+can confirm that it fits this project's deliberately narrow scope.
 
-This project has been developed with help from AI coding tools including Claude Code, Windsurf, and Codex. Human judgment owns the scope, defaults, safety posture, and final review.
+## Setup
 
+```bash
+uv sync
+```
 
-## Project Specification
-- **Python**: `>=3.11`
-- **Runner**: Astral `uv`
-- **Lint/Format**: `ruff`
-- **Typing**: `ty`
-- **Testing**: `pytest`
-- **Entrypoint**: `main.py`
-- **Config**: `config.py`
-- **Secrets**: `.env` (loaded via `python-dotenv`)
-- **External Tool**: `speedtest` (via `brew`)
-- **Agent Guide**: `AGENTS.md`
+## Checks
 
+```bash
+uv run ruff check .
+uv run ruff format . --check
+uv run ty check
+uv run pytest -q
+```
 
-## Core Commands
-- **Sync Dependencies**: `uv sync`
-- **Run Application**: `uv run python main.py`
-- **Run Tests**: `uv run pytest -q`
-- **Check & Fix All**: `uv run ruff check --fix . && uv run ruff format . && uv run ty check && uv run pytest -q`
-- **Add Dependency**: `uv add <package>`
-* * *
-
-
-## Zero-Setup Execution (`main.py`)
-`main.py` uses `uv` script dependency metadata so the app can run with `uv run python main.py` without a prior `uv sync`.
-
-Keep the runtime dependencies in `main.py` in sync with the core application dependencies in `pyproject.toml`.
-* * *
-
-
-## Development Workflow & PR Checklist
-1. Branch from `main`.
-2. Make small, atomic commits using the Conventional Commits spec.
-3. Ensure all checks pass locally before opening a Pull Request:
-
-    - `uv run ruff check --fix . && uv run ruff format .`
-      - (see [pyproject.toml](pyproject.toml) for ruff criteria)
-    - `uv run ty check`
-    - `uv run pytest -q`
-
-4. The PR must have a clear summary of the problem and solution.
-5. Confirm there is no scope creep.
-6. Do not commit secrets.
+Please keep changes focused, update tests or documentation when behavior changes, and do not commit
+`.env` files, network logs, CSV output, or other local data.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A focused macOS diagnostic script for AT&T fiber gateways. It compares gateway-s
 
 If the gateway path is healthy but the local path is not, look closer to the LAN or client device. If both degrade together, you have better evidence for an ISP-facing problem.
 
+This is a personal hobby project maintained on a best-effort basis. It is useful for the setup it was
+built around, but other gateway models and network environments may need adjustments.
+
 ## Requirements
 
 - macOS with Homebrew.
@@ -117,11 +120,7 @@ uv run ty check
 uv run pytest -q
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
-
-For AI coding agents and other automated contributors, see [AGENTS.md](AGENTS.md). This repo keeps scope, commands, safety constraints, and verification expectations explicit so small changes are easier to review.
-
-AI-assisted development is welcome here, with human review and the same checks as hand-written changes.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the small-project contribution workflow.
 
 ## License
 


### PR DESCRIPTION
## What changed
- state the project’s best-effort hobby scope in the README
- replace the oversized contribution guide with a short practical workflow
- remove public AI-tool attribution boilerplate
- pin CI actions, use locked dependencies, and grant read-only permissions

## Validation
- Ruff lint and format checks
- ty
- 45 pytest tests